### PR TITLE
Autodetect executable path & use pythonic tool names.

### DIFF
--- a/wb_runner.py
+++ b/wb_runner.py
@@ -664,23 +664,6 @@ class DataInput(tk.Frame):
 
 class WbRunner(tk.Frame):
     def __init__(self, tool_name=None, master=None):
-        # First, try to find the WhiteboxTools exe directory
-        if _platform == 'win32':
-            ext = '.exe'
-        else:
-            ext = ''
-
-        exe_name = "whitebox_tools{}".format(ext)
-
-        self.exe_path = path.dirname(path.abspath(__file__))
-        os.chdir(self.exe_path)
-        for filename in glob.iglob('**/*', recursive=True):
-            if filename.endswith(exe_name):
-                self.exe_path = path.dirname(path.abspath(filename))
-                break
-
-        wbt.set_whitebox_dir(self.exe_path)
-
         ttk.Frame.__init__(self, master)
         self.script_dir = os.path.dirname(os.path.realpath(__file__))
         self.grid()

--- a/wb_runner.py
+++ b/wb_runner.py
@@ -25,7 +25,7 @@ from tkinter.scrolledtext import ScrolledText
 from tkinter import filedialog
 from tkinter import messagebox
 import webbrowser
-from whitebox_tools import WhiteboxTools
+from whitebox_tools import WhiteboxTools, to_camelcase
 
 wbt = WhiteboxTools()
 
@@ -1032,13 +1032,12 @@ class WbRunner(tk.Frame):
     def get_tools_list(self):
         list = []
         selected_item = -1
-        for item in wbt.list_tools().splitlines():
+        for item in wbt.list_tools().keys():
             if item:
-                if "available tools" not in item.lower():
-                    value = item.split(":")[0]
-                    list.append(value)
-                    if value == self.tool_name:
-                        selected_item = len(list) - 1
+                value = to_camelcase(item)
+                list.append(value)
+                if value == self.tool_name:
+                    selected_item = len(list) - 1
         if selected_item == -1:
             selected_item = 0
             self.tool_name = list[0]

--- a/whitebox_tools.py
+++ b/whitebox_tools.py
@@ -14,6 +14,7 @@ import os
 from os import path
 import sys
 import platform
+import re
 import shutil
 from subprocess import CalledProcessError, Popen, PIPE, STDOUT
 
@@ -308,11 +309,17 @@ class WhiteboxTools(object):
             proc = Popen(args, shell=False, stdout=PIPE,
                          stderr=STDOUT, bufsize=1, universal_newlines=True)
             ret = {}
+            line = proc.stdout.readline() # skip number of available tools header
             while True:
                 line = proc.stdout.readline()
+                print(line)
                 if line != '':
-                    name, descr = line.split(':')
-                    ret[name.strip()] = descr.strip()
+                    if line.strip() != '':
+                        name, descr = line.split(':')
+                        # convert camelCase to snake_case
+                        s1 = re.sub('(.)([A-Z][a-z]+)', r'\1_\2', name)
+                        name = re.sub('([a-z0-9])([A-Z])', r'\1_\2', s1).lower()
+                        ret[name.strip()] = descr.strip()
                 else:
                     break
 

--- a/whitebox_tools.py
+++ b/whitebox_tools.py
@@ -38,7 +38,7 @@ class WhiteboxTools(object):
         else:
             self.ext = ''
         self.exe_name = "whitebox_tools{}".format(self.ext)
-        self.exe_path = os.path.dirname(shutil.which(self.exe_name) or '')
+        self.exe_path = os.path.dirname(shutil.which(self.exe_name) or './')
         self.work_dir = ""
         self.verbose = True
         self.cancel_op = False

--- a/whitebox_tools.py
+++ b/whitebox_tools.py
@@ -13,7 +13,7 @@ from __future__ import print_function
 import os
 from os import path
 import sys
-from sys import platform
+import platform
 from subprocess import CalledProcessError, Popen, PIPE, STDOUT
 
 
@@ -37,7 +37,7 @@ class WhiteboxTools(object):
         self.verbose = True
         self.cancel_op = False
 
-    if platform == 'win32':
+    if platform.system() == 'Windows':
         ext = '.exe'
     else:
         ext = ''

--- a/whitebox_tools.py
+++ b/whitebox_tools.py
@@ -28,6 +28,21 @@ def default_callback(value):
     print(value)
 
 
+def to_camelcase(name):
+    '''
+    Convert snake_case name to CamelCase name 
+    '''
+    return ''.join(x.title() for x in name.split('_'))
+
+
+def to_snakecase(name):
+    '''
+    Convert CamelCase name to snake_case name 
+    '''
+    s1 = re.sub('(.)([A-Z][a-z]+)', r'\1_\2', name)
+    return re.sub('([a-z0-9])([A-Z])', r'\1_\2', s1).lower()
+
+
 class WhiteboxTools(object):
     ''' 
     An object for interfacing with the WhiteboxTools executable.
@@ -82,7 +97,7 @@ class WhiteboxTools(object):
             os.chdir(self.exe_path)
             args2 = []
             args2.append("." + path.sep + self.exe_name)
-            args2.append("--run=\"{}\"".format(tool_name))
+            args2.append("--run=\"{}\"".format(to_camelcase(tool_name)))
 
             if self.work_dir.strip() != "":
                 args2.append("--wd=\"{}\"".format(self.work_dir))
@@ -204,7 +219,7 @@ class WhiteboxTools(object):
             os.chdir(self.exe_path)
             args = []
             args.append("." + os.path.sep + self.exe_name)
-            args.append("--toolhelp={}".format(tool_name))
+            args.append("--toolhelp={}".format(to_camelcase(tool_name)))
 
             proc = Popen(args, shell=False, stdout=PIPE,
                          stderr=STDOUT, bufsize=1, universal_newlines=True)
@@ -228,7 +243,7 @@ class WhiteboxTools(object):
             os.chdir(self.exe_path)
             args = []
             args.append("." + os.path.sep + self.exe_name)
-            args.append("--toolparameters={}".format(tool_name))
+            args.append("--toolparameters={}".format(to_camelcase(tool_name)))
 
             proc = Popen(args, shell=False, stdout=PIPE,
                          stderr=STDOUT, bufsize=1, universal_newlines=True)
@@ -252,7 +267,7 @@ class WhiteboxTools(object):
             os.chdir(self.exe_path)
             args = []
             args.append("." + os.path.sep + self.exe_name)
-            args.append("--toolbox={}".format(tool_name))
+            args.append("--toolbox={}".format(to_camelcase(tool_name)))
 
             proc = Popen(args, shell=False, stdout=PIPE,
                          stderr=STDOUT, bufsize=1, universal_newlines=True)
@@ -277,7 +292,7 @@ class WhiteboxTools(object):
             os.chdir(self.exe_path)
             args = []
             args.append("." + os.path.sep + self.exe_name)
-            args.append("--viewcode={}".format(tool_name))
+            args.append("--viewcode={}".format(to_camelcase(tool_name)))
 
             proc = Popen(args, shell=False, stdout=PIPE,
                          stderr=STDOUT, bufsize=1, universal_newlines=True)
@@ -316,10 +331,7 @@ class WhiteboxTools(object):
                 if line != '':
                     if line.strip() != '':
                         name, descr = line.split(':')
-                        # convert camelCase to snake_case
-                        s1 = re.sub('(.)([A-Z][a-z]+)', r'\1_\2', name)
-                        name = re.sub('([a-z0-9])([A-Z])', r'\1_\2', s1).lower()
-                        ret[name.strip()] = descr.strip()
+                        ret[to_snakecase(name.strip())] = descr.strip()
                 else:
                     break
 

--- a/whitebox_tools.py
+++ b/whitebox_tools.py
@@ -14,6 +14,7 @@ import os
 from os import path
 import sys
 import platform
+import shutil
 from subprocess import CalledProcessError, Popen, PIPE, STDOUT
 
 
@@ -32,17 +33,15 @@ class WhiteboxTools(object):
     '''
 
     def __init__(self):
-        self.exe_path = path.dirname(path.abspath(__file__))
+        if platform.system() == 'Windows':
+            self.ext = '.exe'
+        else:
+            self.ext = ''
+        self.exe_name = "whitebox_tools{}".format(ext)
+        self.exe_path = os.path.dirname(shutil.which(exe_name) or '')
         self.work_dir = ""
         self.verbose = True
         self.cancel_op = False
-
-    if platform.system() == 'Windows':
-        ext = '.exe'
-    else:
-        ext = ''
-
-    exe_name = "whitebox_tools{}".format(ext)
 
     def set_whitebox_dir(self, path_str):
         ''' 

--- a/whitebox_tools.py
+++ b/whitebox_tools.py
@@ -327,7 +327,6 @@ class WhiteboxTools(object):
             line = proc.stdout.readline() # skip number of available tools header
             while True:
                 line = proc.stdout.readline()
-                print(line)
                 if line != '':
                     if line.strip() != '':
                         name, descr = line.split(':')

--- a/whitebox_tools.py
+++ b/whitebox_tools.py
@@ -37,8 +37,8 @@ class WhiteboxTools(object):
             self.ext = '.exe'
         else:
             self.ext = ''
-        self.exe_name = "whitebox_tools{}".format(ext)
-        self.exe_path = os.path.dirname(shutil.which(exe_name) or '')
+        self.exe_name = "whitebox_tools{}".format(self.ext)
+        self.exe_path = os.path.dirname(shutil.which(self.exe_name) or '')
         self.work_dir = ""
         self.verbose = True
         self.cancel_op = False

--- a/whitebox_tools.py
+++ b/whitebox_tools.py
@@ -307,11 +307,12 @@ class WhiteboxTools(object):
 
             proc = Popen(args, shell=False, stdout=PIPE,
                          stderr=STDOUT, bufsize=1, universal_newlines=True)
-            ret = ""
+            ret = {}
             while True:
                 line = proc.stdout.readline()
                 if line != '':
-                    ret += line
+                    name, descr = line.split(':')
+                    ret[name.strip()] = descr.strip()
                 else:
                     break
 


### PR DESCRIPTION
This PR does the following:

1. Autodetect availability of whitebox_tools in path and set exe_path automatically 
2. Use pythonic tool names (i.e. snake_case) in all the python functions. i.e. ` wbt.tool_help('rescale_value_range')` instead of ` wbt.tool_help('RescaleValueRange')`
3. wbt.list_tools() returns a dictionary of {tool_name: description} instead of a string.
4. Associated fixes to keep wb_runner.py working.

These changes ease usage from python and allow for installation of whitebox_tools as a python package that can be imported by other packages. I am also build conda packages (see https://github.com/conda-forge/whitebox_tools-feedstock/pull/1) which will allow for installation of whitebox-tools easily in python. I'm just repackaging the zip files available from your website and adding a setup.py and putting the executable in the correct location. This will allow us to install whitebox_tools within a conda python environment using:

`conda install -c conda-forge whitebox_tools`