### PR TITLE
Update all shebangs to python 3

### DIFF
--- a/build.py
+++ b/build.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 ''' this module is used to build whitebox-tools.
 '''
 import os

--- a/lib_test.py
+++ b/lib_test.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python3
 ''' This script is intended to experiment with the use of a whitebox_tools shared library (DLL).
 It is experimental and is not intended for widespread use.
 '''

--- a/wb_runner.py
+++ b/wb_runner.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 # This script is part of the WhiteboxTools geospatial analysis library.
 # Authors: Dr. John Lindsay

--- a/whitebox_example.py
+++ b/whitebox_example.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 ''' This module provides examples of how to call the whitebox_tool script and the
 whitebox-tools geospatial analysis library using Python code.
 '''

--- a/whitebox_plugin_generator.py
+++ b/whitebox_plugin_generator.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python3
 """
 This script is just used to automatically generate the convenience methods for each
 of the plugin tools in the whitebox_tools.py script. It should be run each time new

--- a/whitebox_tools.py
+++ b/whitebox_tools.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 ''' This file is intended to be a helper for running whitebox-tools plugins from a Python script.
 See whitebox_example.py for an example of how to use it.
 '''


### PR DESCRIPTION
The readme says that all the python scripts are Python 3 only, but the shebangs in the files do not reflect this, so I updated the shebangs at the tops of the python files to be:

`#!/usr/bin/env python3`

This allows the files to be run directly on systems where Python 2 is still default.