### PR TITLE
Docker image

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,13 @@ the *GoSpatial* project, having subsumed all of its functionality.
 
 ## 2 Downloads and Installation
 
-*WhiteboxTools* is a stand-alone executable command-line program with no actual installation. If you intend to use the Python programming interface for *WhiteboxTools* you will need to have Python 3 (or higher) installed. Pre-compiled binaries can be downloaded from the [*Geomorphometry and Hydrogeomatics Research Group*](http://www.uoguelph.ca/~hydrogeo/WhiteboxTools/index.html) software web site for various supported operating systems. It is likely that *WhiteboxTools* will work on a wider variety of operating systems and architectures than the distributed binary files. If you do not find your operating system/architecture in the list of available *WhiteboxTool* binaries, then compilation from source code will be necessary. WhiteboxTools can be compiled from the source code with the following steps:
+### Pre-compiled binaries
+
+*WhiteboxTools* is a stand-alone executable command-line program with no actual installation. If you intend to use the Python programming interface for *WhiteboxTools* you will need to have Python 3 (or higher) installed. Pre-compiled binaries can be downloaded from the [*Geomorphometry and Hydrogeomatics Research Group*](http://www.uoguelph.ca/~hydrogeo/WhiteboxTools/index.html) software web site for various supported operating systems.
+
+### Building from source code
+
+It is likely that *WhiteboxTools* will work on a wider variety of operating systems and architectures than the distributed binary files. If you do not find your operating system/architecture in the list of available *WhiteboxTool* binaries, then compilation from source code will be necessary. WhiteboxTools can be compiled from the source code with the following steps:
 
 1. Install the Rust compiler; Rustup is recommended for this purpose. Further instruction can be found at this [link](https://www.rust-lang.org/en-US/install.html).
 
@@ -68,6 +74,38 @@ the *GoSpatial* project, having subsumed all of its functionality.
 Depending on your system, the compilation may take several minutes. When completed, the compiled binary executable file will be contained within the *whitebox-tools/target/release/ folder*. Type *./whitebox_tools --help* at the command prompt (after cd'ing to the containing folder) for information on how to run the executable from the terminal.
 
 Be sure to follow the instructions for installing Rust carefully. In particular, if you are installing on MS Windows, you must have a linker installed prior to installing the Rust compiler (rustc). The Rust webpage recommends either the **MS Visual C++ 2015 Build Tools** or the GNU equivalent and offers details for each installation approach. You should also consider using **RustUp** to install the Rust compiler.
+
+### Using Docker image
+
+For these who don't want to build from sources or can not use pre-build binaries there is also a Docker container that runs Whitebox Tools.
+
+To build the image do:
+
+1. clone Whitebox Tools repository to your local system or download code archive from the GitHub
+
+    ```
+    git clone https://github.com/jblindsay/whitebox-tools.git
+    ```
+
+2. Open a terminal (command prompt) window and change the working directory to the whitebox-tools folder
+
+    ```
+    cd /path/to/folder/whitebox-tools/
+    ```
+
+3. Build container
+
+    ```
+    docker build -t whitebox-tools -f docker/whitebox-tools.dockerfile .
+    ```
+
+4. Depending on your system, the build process may take several minutes. When completed, new image called `whitebox-tool` will be created.
+
+To use container it is necessary to bind mount data directory into container as `/data` and then pass required command-line arguments, like below
+
+```
+docker run --rm -it -v "/path/to/data/directory/":/data whitebox-tools --run=IntegralImage -i=dem.tif -o=out.tif
+```
 
 ## 3 Usage
 

--- a/docker/whitebox-tools.dockerfile
+++ b/docker/whitebox-tools.dockerfile
@@ -1,0 +1,15 @@
+ARG DOCKER_TAG=latest
+
+FROM rust:latest AS builder
+
+RUN apt-get update && apt-get install -y musl-tools
+RUN rustup target add x86_64-unknown-linux-musl
+
+COPY . /wbt
+WORKDIR /wbt
+RUN cargo build --release --target x86_64-unknown-linux-musl
+
+FROM alpine:latest
+COPY --from=builder /wbt/target/x86_64-unknown-linux-musl/release/whitebox_tools /usr/local/bin/
+
+ENTRYPOINT ["whitebox_tools", "-v", "--wd=/data"]


### PR DESCRIPTION
First attempt to create Docker image for Whitebox Tools.

Useful for these who can't/want build WBT from source or use pre-compiled binaries. Also such image platform-independent and can be used on any system capable to run Docker itself. To use Whitebox Tools from thic image one need to bind-mount working directory into container's `/data` directory and then use WBT as usuall except few Docker-specific additions. For example, following command will execute "IntegralImage" tool on file `dem.tif` located in `/home/user/data/` and save output as `out.tif` into same `/home/user/data/` directory

```
docker run --rm -it -v "/home/user/data/":/data whitebox-tools --run=IntegralImage -i=dem.tif -o=out.tif
```

If necessary a simple wrapper script can be created to hide Docker-specific stuff.

The only disadvantage I see for now is a requirement to keep all data used for analysis in the same working directory.