### PR TITLE
Corrected output type for Polygon Long Axis

### DIFF
--- a/manual/WhiteboxToolsManual.md
+++ b/manual/WhiteboxToolsManual.md
@@ -2471,7 +2471,7 @@ therefore a vector of simple two-point polylines forming a vector field.
 **Flag**             **Description**
 -------------------  ---------------
 -i, -\-input         Input vector polygons file
--o, -\-output        Output vector polygon file
+-o, -\-output        Output vector polyline file
 
 
 *Python function*:


### PR DESCRIPTION
Polygon Long Axis was incorrectly reporting that output type is a Polygon when it is a Polyline. Have updated the WhiteboxToolsManual.md file, hope this was the correct file to correct? I have never edited a md manual file before.