### PR TITLE
Explicitly calls for slope file in degrees

### DIFF
--- a/src/tools/terrain_analysis/wetness_index.rs
+++ b/src/tools/terrain_analysis/wetness_index.rs
@@ -46,7 +46,7 @@ impl WetnessIndex {
         parameters.push(ToolParameter {
             name: "Input Slope File".to_owned(),
             flags: vec!["--slope".to_owned()],
-            description: "Input raster slope file.".to_owned(),
+            description: "Input raster slope file (in degrees).".to_owned(),
             parameter_type: ParameterType::ExistingFile(ParameterFileType::Raster),
             default_value: None,
             optional: false,


### PR DESCRIPTION
I was using a slope raster generated form outside WhiteboxTools and wasn't sure if my slope raster in percentage was appropriate. I didn't find the info in the tool's help so I had to go look the code. I could have also tried rasters in degrees, radians and percentage and looked at what made sense but... I didn't.