### PR TITLE
D8FlowAccumulation: ensure float output when using d8 pointer input

### DIFF
--- a/src/tools/hydro_analysis/d8_flow_accum.rs
+++ b/src/tools/hydro_analysis/d8_flow_accum.rs
@@ -454,6 +454,7 @@ impl WhiteboxTool for D8FlowAccumulation {
 
         let mut output = Raster::initialize_using_file(&output_file, &input);
         output.configs.photometric_interp = PhotometricInterpretation::Continuous; // if the input is a pointer, this may not be the case by default.
+        output.configs.data_type = DataType::F64;
         output.reinitialize_values(1.0);
         drop(input);
 


### PR DESCRIPTION
I noticed a regression after upgrading from version 1.3.0 to 1.4.0 when using the _D8FlowAccumulation_ tool. Consider the following commands:

```
whitebox_tools --cd=. --run=D8Pointer --dem=dem.tif --output=pnt.tif
whitebox_tools --cd=. --run=D8FlowAccumulation --input=pnt.tif --output=acc.tif --pntr --out_type="catchment area"
```

Using version 1.3.0, the resulting accumulation raster, `acc.tif`, is a 64-bit float raster. With version 1.4.0, a 16-bit integer raster is produced. I don't think this is a suitable output format, as the values contained in the accumulation raster will likely exceed the maximum possible value of a 16-bit integer.

The commit which introduced this bug is [this one](https://github.com/jblindsay/whitebox-tools/commit/f23d4405cf4eb28a9d73b2979307bf62a7118a79) (and its [follow-up](https://github.com/jblindsay/whitebox-tools/commit/472439ee1bbef75134190edfa932e397a0a8fb78)), which changed the _D8Pointer_ tool to produce U16 integer rasters. Since the _D8FlowAccumulation_ tool takes its output raster characteristics directly from the input raster, this causes the output raster data type to be U16 when the `--pntr` flag is specified and the input D8 pointer raster is generated by _D8Pointer_ tool.

This commit overrides the data type of the _D8FlowAccumulation_ output raster to always be floating point. Just a single line does the trick. (I chose F64 as the data type, but I can change it to F32 if you think that would suffice.)

I checked through the source for other tools using a `--pntr` or `--d8_pntr` parameter. I found that the _FindParallelFlow_ tool may also be affected by this bug. (See [here](https://github.com/jblindsay/whitebox-tools/blob/db8423fd1e9b884ab9c6cd11eff7309c1e892a0a/src/tools/hydro_analysis/find_parallel_flow.rs#L222), where the data_type is not overridden). But I'm not well-equipped to investigate, so I'll leave it to you.

I hope this helps! Thanks for a great project.
