### PR TITLE
Support for Geotiff ModelTransformationTag = 34264 (JPL Carto Group) …

### DIFF
--- a/whitebox-raster/src/geotiff/mod.rs
+++ b/whitebox-raster/src/geotiff/mod.rs
@@ -598,6 +598,21 @@ pub fn read_geotiff<'a>(
         }
         _ => {}
     }
+    match ifd_map.get(&34264) {
+        Some(ifd) => {
+            let vals = ifd.interpret_as_f64();
+            if vals.len() != 16 {
+                return Err(Error::new(
+                    ErrorKind::InvalidData,
+                    "Error: the ModelTransformationTag (34264) is not specified correctly in the GeoTIFF file.",
+                ));
+            }
+            for i in 0..16 {
+                configs.model_transformation[i] = vals[i];
+            }
+        }
+        _ => {}
+    }
 
     if configs.model_tiepoint.len() == 6 {
         // see if the model_pixel_scale tag was actually specified


### PR DESCRIPTION
Hello, 

this is a pull request to provide support for Geotiff ModelTransformationTag = 34264 (JPL Carto Group) 
Whitebox tools already has support for the obsolete IntergraphMatrixTag = 33920 (Intergraph) which has been superceeded by the one with the number tag above, which bears the exact same parameters as already implemented

(see http://geotiff.maptools.org/spec/geotiff6.html) 
(see https://www.awaresystems.be/imaging/tiff/tifftags/docs/intergraph.html)

Thank you in advance.
If you deem it worthwhile, I also provided a separate branch for integration in v1.4.x
https://github.com/mbettini-topcon/whitebox-tools/tree/v1.4/geotiff-tag-34264-JPL