### PR TITLE
Fix missing last connection in CSV

### DIFF
--- a/whitebox-tools-app/src/tools/hydro_analysis/isobasins.rs
+++ b/whitebox-tools-app/src/tools/hydro_analysis/isobasins.rs
@@ -467,7 +467,7 @@ impl WhiteboxTool for Isobasins {
             }
         }
 
-        let num_outlets = outlet_id as usize - 1;
+        let num_outlets = outlet_id as usize;
 
         //////////////////////////////////////////
         // Trace flowpaths to their pour points //


### PR DESCRIPTION
The number of outlets `num_outlets` was one short of the truth causing the lost of the connection for the last outlet.