### PR TITLE
Prevent activation of shell window

### DIFF
--- a/whitebox_tools.py
+++ b/whitebox_tools.py
@@ -115,7 +115,7 @@ class WhiteboxTools(object):
             if running_windows and self.start_minimized == True:
                 si = STARTUPINFO()
                 si.dwFlags = STARTF_USESHOWWINDOW
-                si.wShowWindow = 6 #Set window minimized
+                si.wShowWindow = 7 #Set window minimized and not activated
                 proc = Popen(args2, shell=False, stdout=PIPE,
                             stderr=STDOUT, bufsize=1, universal_newlines=True,
                             startupinfo=si)
@@ -201,7 +201,7 @@ class WhiteboxTools(object):
             if running_windows and self.start_minimized == True:
                 si = STARTUPINFO()
                 si.dwFlags = STARTF_USESHOWWINDOW
-                si.wShowWindow = 6 #Set window minimized
+                si.wShowWindow = 7 #Set window minimized and not activated
                 proc = Popen(args2, shell=False, stdout=PIPE,
                             stderr=STDOUT, bufsize=1, universal_newlines=True,
                             startupinfo=si)


### PR DESCRIPTION
Using `si.wShowWindow = 7` minimizes window but doesn't active it ([ref](https://docs.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-showwindow)). It prevents losing focus briefly on your current active window which is annoying if you happen to type while the process is launched as a few keystrokes will be lost.