### PR TITLE
fix outlet_id increment

### DIFF
--- a/whitebox-tools-app/src/tools/hydro_analysis/isobasins.rs
+++ b/whitebox-tools-app/src/tools/hydro_analysis/isobasins.rs
@@ -478,7 +478,7 @@ impl WhiteboxTool for Isobasins {
             }
         }
 
-        let num_outlets = outlet_id as usize;
+        let num_outlets = outlet_id as usize;  // in truth, it's the number of outlets plus one
 
         //////////////////////////////////////////
         // Trace flowpaths to their pour points //

--- a/whitebox-tools-app/src/tools/hydro_analysis/isobasins.rs
+++ b/whitebox-tools-app/src/tools/hydro_analysis/isobasins.rs
@@ -407,13 +407,16 @@ impl WhiteboxTool for Isobasins {
         let mut fa: usize;
         let mut inla_index: usize;
         let mut inla_mag: usize;
+        let mut flag_target: bool;
         while !stack.is_empty() {
             let cell = stack.pop().expect("Error during pop operation.");
             row = cell.0;
             col = cell.1;
             fa = accum.get_value(row, col);
+            flag_target = false;
             if fa >= target_fa {
                 // find the index of the inflowing neighbour with the largest accumulation
+                flag_target = true;
                 inla_mag = 0;
                 inla_index = 8;
                 for i in 0..8 {
@@ -434,6 +437,7 @@ impl WhiteboxTool for Isobasins {
                         fa -= inla_mag;
                         output.set_value(row_n, col_n, outlet_id);
                         outlet_id += 1f64;
+                        flag_target = false;
                     } else {
                         accum.set_value(row, col, 1);
                         fa = 1;
@@ -458,8 +462,10 @@ impl WhiteboxTool for Isobasins {
                     stack.push((row_n, col_n));
                 }
             } else {
-                output.set_value(row, col, outlet_id);
-                outlet_id += 1f64;
+                if !flag_target {
+                    output.set_value(row, col, outlet_id);
+                    outlet_id += 1f64;
+                }
             }
 
             if verbose {
@@ -472,7 +478,7 @@ impl WhiteboxTool for Isobasins {
             }
         }
 
-        let num_outlets = outlet_id as usize - 1;
+        let num_outlets = outlet_id as usize;
 
         //////////////////////////////////////////
         // Trace flowpaths to their pour points //


### PR DESCRIPTION
Fix for #172 and more complete PR than #165.

It's not to my liking, but it works. I suppose there is a more elegant way to do it by reworking the logic inside the while loop.

The main issue was when `inla_index < 8` was True for the before last basin [(line 430)](https://github.com/jblindsay/whitebox-tools/blob/6ebeab23fd40dedcf112612402bf5b4551c2bb1e/whitebox-tools-app/src/tools/hydro_analysis/isobasins.rs#L430) as it would add one to `outlet_id` there but also after at [(line 462)](https://github.com/jblindsay/whitebox-tools/blob/6ebeab23fd40dedcf112612402bf5b4551c2bb1e/whitebox-tools-app/src/tools/hydro_analysis/isobasins.rs#L462) when `dir >= 0` was False.