### PR TITLE
isobasins: simplify target_fa check

### DIFF
--- a/whitebox-tools-app/src/tools/hydro_analysis/isobasins.rs
+++ b/whitebox-tools-app/src/tools/hydro_analysis/isobasins.rs
@@ -427,22 +427,18 @@ impl WhiteboxTool for Isobasins {
                     }
                 }
                 if (target_fa - inla_mag) < (fa - target_fa) {
-                    if inla_index < 8 {
-                        row_n = row + dy[inla_index];
-                        col_n = col + dx[inla_index];
-                        accum.decrement(row, col, inla_mag);
-                        fa -= inla_mag;
-                        output.set_value(row_n, col_n, outlet_id);
-                        outlet_id += 1f64;
-                    } else {
-                        accum.set_value(row, col, 1);
-                        fa = 1;
-                        output.set_value(row, col, outlet_id);
-                        outlet_id += 1f64;
-                    }
+                    // create an independant basin for the inflowing neighbour
+                    // when its accumulation is contributing for a significant
+                    // amount of the accumulation of the cell currently evaluated
+                    row_n = row + dy[inla_index];
+                    col_n = col + dx[inla_index];
+                    accum.decrement(row, col, inla_mag);
+                    fa -= inla_mag;
+                    output.set_value(row_n, col_n, outlet_id);
+                    outlet_id += 1f64;
                 } else {
                     accum.set_value(row, col, 1);
-                    fa = 1;
+                    fa = 0;
                     output.set_value(row, col, outlet_id);
                     outlet_id += 1f64;
                 }


### PR DESCRIPTION
I may be mistaken, but the condition `inla_index < 8` will always be `true` because the only way to get `false` is if no inflowing neighbour exists... which is not possible because in order to enter the main loop, the condition `fa >= target_fa` must be `true` which itself imply that the cell has at least one inflowing neighbour. Even the odd case where `target_fa` equals `1` won't cause an issue because `(target_fa - inla_mag) < (fa - target_fa)` will be `false`.

https://github.com/jblindsay/whitebox-tools/blob/6ebeab23fd40dedcf112612402bf5b4551c2bb1e/whitebox-tools-app/src/tools/hydro_analysis/isobasins.rs#L429-L442

In the `else` statement, I now reset `fa` to `0` instead of `1` as it was erroneously adding 1 cell of accumulation for each nested basin afterwards:
https://github.com/jblindsay/whitebox-tools/blob/6ebeab23fd40dedcf112612402bf5b4551c2bb1e/whitebox-tools-app/src/tools/hydro_analysis/isobasins.rs#L455