### PR TITLE
fill_burn: decrease all stream cells by 1

### DIFF
--- a/whitebox-tools-app/src/tools/hydro_analysis/fill_burn.rs
+++ b/whitebox-tools-app/src/tools/hydro_analysis/fill_burn.rs
@@ -584,7 +584,7 @@ impl WhiteboxTool for FillBurn {
             }
         }
 
-        // Find the minimum elevaton difference between the
+        // Find the minimum elevation difference between the
         // filled DEM and the original DEM along the
         // stream network and raise all stream cells by this
         // value less 1 m.
@@ -607,7 +607,7 @@ impl WhiteboxTool for FillBurn {
             }
         }
 
-        min_diff += 1f64;
+        min_diff -= 1f64;
 
         for row in 0..rows {
             for col in 0..columns {

--- a/whitebox-tools-app/src/tools/hydro_analysis/fill_burn.rs
+++ b/whitebox-tools-app/src/tools/hydro_analysis/fill_burn.rs
@@ -22,8 +22,8 @@ use std::sync::mpsc;
 use std::sync::Arc;
 use std::thread;
 
-/// Burns streams into a DEM using the FillBurn (Saunders, 1999) method. This tool uses the
-/// algorithm described in:
+/// Burns streams into a DEM using the FillBurn (Saunders, 1999) method which produces a hydro-enforced DEM.
+/// This tool uses the algorithm described in:
 ///
 /// Lindsay JB. 2016. The practice of DEM stream burning revisited. Earth Surface Processes
 /// and Landforms, 41(5): 658-668. DOI: 10.1002/esp.3888


### PR DESCRIPTION
The current tool was overfilling all stream cells by 1 unit instead of underfilling by 1 unit.