### PR TITLE
isobasins: provide additional connection attributes

### DIFF
--- a/whitebox-tools-app/src/tools/hydro_analysis/isobasins.rs
+++ b/whitebox-tools-app/src/tools/hydro_analysis/isobasins.rs
@@ -30,8 +30,8 @@ use std::thread;
 /// The tool can optionally (`--connections`) output a CSV table that contains the upstream/downstream connections
 /// among isobasins. That is, this table will identify the downstream basin of each isobasin, or will list N/A in
 /// the event that there is no downstream basin, i.e. if it drains to an edge. The table also contains the number of
-/// cells in each isobasins, the position of each outlet (in raster grid coordinates with indexing starting at zero)
-/// along with the D8 pointer expressed with the same clockwise, base-2 numeric index convention used in `D8Pointer`.
+/// cells in each isobasin, the position of each outlet (in raster grid coordinates with indexing starting at zero)
+/// along with the D8 pointer expressed with the same base-2 numeric index convention used in the `D8Pointer` tool.
 /// The output CSV file will have the same name as the output raster, but with a *.csv file extension.
 ///
 /// # See Also

--- a/whitebox-tools-app/src/tools/hydro_analysis/isobasins.rs
+++ b/whitebox-tools-app/src/tools/hydro_analysis/isobasins.rs
@@ -427,22 +427,18 @@ impl WhiteboxTool for Isobasins {
                     }
                 }
                 if (target_fa - inla_mag) < (fa - target_fa) {
-                    if inla_index < 8 {
-                        row_n = row + dy[inla_index];
-                        col_n = col + dx[inla_index];
-                        accum.decrement(row, col, inla_mag);
-                        fa -= inla_mag;
-                        output.set_value(row_n, col_n, outlet_id);
-                        outlet_id += 1f64;
-                    } else {
-                        accum.set_value(row, col, 1);
-                        fa = 1;
-                        output.set_value(row, col, outlet_id);
-                        outlet_id += 1f64;
-                    }
+                    // create an independant basin for the inflowing neighbour
+                    // when its accumulation is contributing for a significant
+                    // amount of the accumulation of the cell currently evaluated
+                    row_n = row + dy[inla_index];
+                    col_n = col + dx[inla_index];
+                    accum.decrement(row, col, inla_mag);
+                    fa -= inla_mag;
+                    output.set_value(row_n, col_n, outlet_id);
+                    outlet_id += 1f64;
                 } else {
                     accum.set_value(row, col, 1);
-                    fa = 1;
+                    fa = 0;
                     output.set_value(row, col, outlet_id);
                     outlet_id += 1f64;
                 }


### PR DESCRIPTION
Provide 4 new attributes in the CSV table:
- NBCELLS -> the number of celles inside the isobasin
- D8POINTER -> the D8 pointer of the outlet using the same base-2 numeric index convention used in the D8Pointer tool
- ROW -> the row number of the outlet using the raster grid coordinates with zero-indexing (0 being at the top)
- COL -> the column number of the outlet using the raster grid coordinates with zero-indexing (0 being at the left)

These new attributes allow the creation of a layer vector with arrows showing where the connections between happen.

Consider changes in #173 and #174.