### PR TITLE
Fix row bytes number and prevent invalid PRJ in BIL format writer

### DIFF
--- a/whitebox-raster/src/esri_bil.rs
+++ b/whitebox-raster/src/esri_bil.rs
@@ -522,12 +522,12 @@ pub fn write_esri_bil<'a>(r: &'a mut Raster) -> Result<(), Error> {
         .write_all(s.as_bytes())
         .expect("Error while writing to BIL file.");
 
-    let s = format!("BANDROWBYTES   {}\n", nbits / 4 * r.configs.columns);
+    let s = format!("BANDROWBYTES   {}\n", nbits / 8 * r.configs.columns);
     writer
         .write_all(s.as_bytes())
         .expect("Error while writing to BIL file.");
 
-    let s = format!("TOTALROWBYTES  {}\n", nbits / 4 * r.configs.columns);
+    let s = format!("TOTALROWBYTES  {}\n", nbits / 8 * r.configs.columns);
     writer
         .write_all(s.as_bytes())
         .expect("Error while writing to BIL file.");

--- a/whitebox-raster/src/lib.rs
+++ b/whitebox-raster/src/lib.rs
@@ -1246,7 +1246,7 @@ impl Default for RasterConfigs {
             display_min: f64::INFINITY,
             display_max: f64::NEG_INFINITY,
             palette: "not specified".to_string(),
-            projection: "not specified".to_string(),
+            projection: "".to_string(),
             endian: Endianness::LittleEndian,
             photometric_interp: PhotometricInterpretation::Unknown,
             data_type: DataType::Unknown,


### PR DESCRIPTION
Corrects `BANDROWBYTES` and `TOTALROWBYTES` that were off by a factor of 2 and causing issue when files were read by GDAL.

I also changed the default raster config to make the projection definition empty so that if the input file has none defined, the output BIL won't generate an invalide PRJ file (containing the string _not specified_). It will also affect other raster format where PRJ were always generated (like SAGA raster).

https://github.com/jblindsay/whitebox-tools/blob/c9fa7a673d08d891601274ccfc4fc00f39a4e72c/whitebox-raster/src/esri_bil.rs#L573-L588