### PR TITLE
BreachDepressionsLeastCost: set min_dist and fill parameters to False

### DIFF
--- a/whitebox_tools.py
+++ b/whitebox_tools.py
@@ -3832,7 +3832,7 @@ class WhiteboxTools(object):
         if fill_pits: args.append("--fill_pits")
         return self.run_tool('breach_depressions', args, callback) # returns 1 if error
 
-    def breach_depressions_least_cost(self, dem, output, dist, max_cost=None, min_dist=True, flat_increment=None, fill=False, callback=None):
+    def breach_depressions_least_cost(self, dem, output, dist, max_cost=None, min_dist=False, flat_increment=None, fill=False, callback=None):
         """Breaches the depressions in a DEM using a least-cost pathway method.
 
         Keyword arguments:

--- a/whitebox_tools.py
+++ b/whitebox_tools.py
@@ -3832,7 +3832,7 @@ class WhiteboxTools(object):
         if fill_pits: args.append("--fill_pits")
         return self.run_tool('breach_depressions', args, callback) # returns 1 if error
 
-    def breach_depressions_least_cost(self, dem, output, dist, max_cost=None, min_dist=True, flat_increment=None, fill=True, callback=None):
+    def breach_depressions_least_cost(self, dem, output, dist, max_cost=None, min_dist=True, flat_increment=None, fill=False, callback=None):
         """Breaches the depressions in a DEM using a least-cost pathway method.
 
         Keyword arguments:


### PR DESCRIPTION
Since the introduction of the tool in v1.1.0, `min_dist` and `fill` parameters have always been set to `True` by default in the Python API but I think they should be set to `False` instead to match the behaviour when calling it in command-line. It will also fit better the wording of the tool description (being optional flags).