### PR TITLE
Fix typos in whitebox_tools.py and list_tools output

### DIFF
--- a/whitebox-tools-app/src/tools/lidar_analysis/lidar_classify_subset.rs
+++ b/whitebox-tools-app/src/tools/lidar_analysis/lidar_classify_subset.rs
@@ -64,7 +64,7 @@ impl LidarClassifySubset {
         let name = "LidarClassifySubset".to_string();
         let toolbox = "LiDAR Tools".to_string();
         let description =
-            "Classifies the values in one LiDAR point cloud that correpond with points in a subset cloud."
+            "Classifies the values in one LiDAR point cloud that correspond with points in a subset cloud."
                 .to_string();
 
         let mut parameters = vec![];

--- a/whitebox_tools.py
+++ b/whitebox_tools.py
@@ -979,7 +979,7 @@ class WhiteboxTools(object):
         return self.run_tool('centroid', args, callback) # returns 1 if error
 
     def centroid_vector(self, i, output, callback=None):
-        """Identifes the centroid point of a vector polyline or polygon feature or a group of vector points.
+        """Identifies the centroid point of a vector polyline or polygon feature or a group of vector points.
 
         Keyword arguments:
 
@@ -3250,8 +3250,8 @@ class WhiteboxTools(object):
         Keyword arguments:
 
         i -- Name of the input raster image file. 
-        pos_output -- Name of the positive openenness output raster file. 
-        neg_output -- Name of the negative openenness output raster file. 
+        pos_output -- Name of the positive openness output raster file. 
+        neg_output -- Name of the negative openness output raster file. 
         dist -- Search distance, in grid cells. 
         callback -- Custom function for handling tool text outputs.
         """
@@ -3898,7 +3898,7 @@ class WhiteboxTools(object):
         dem -- Name of the input DEM raster file; must be depressionless. 
         output -- Name of the output raster file. 
         exponent -- Optional exponent parameter; default is 1.0. 
-        threshold -- Optional convergence threshold parameter, in grid cells; default is inifinity. 
+        threshold -- Optional convergence threshold parameter, in grid cells; default is infinity. 
         log -- Log-transform the output values?. 
         callback -- Custom function for handling tool text outputs.
         """
@@ -3978,7 +3978,7 @@ class WhiteboxTools(object):
         i -- Input raster DEM or D-infinity pointer file. 
         output -- Output raster file. 
         out_type -- Output type; one of 'cells', 'sca' (default), and 'ca'. 
-        threshold -- Optional convergence threshold parameter, in grid cells; default is inifinity. 
+        threshold -- Optional convergence threshold parameter, in grid cells; default is infinity. 
         log -- Optional flag to request the output be log-transformed. 
         clip -- Optional flag to request clipping the display max by 1%. 
         pntr -- Is the input raster a D-infinity flow pointer rather than a DEM?. 
@@ -4141,7 +4141,7 @@ class WhiteboxTools(object):
         output -- Output raster file. 
         out_type -- Output type; one of 'cells', 'specific contributing area' (default), and 'catchment area'. 
         exponent -- Optional exponent parameter; default is 1.1. 
-        threshold -- Optional convergence threshold parameter, in grid cells; default is inifinity. 
+        threshold -- Optional convergence threshold parameter, in grid cells; default is infinity. 
         log -- Optional flag to request the output be log-transformed. 
         clip -- Optional flag to request clipping the display max by 1%. 
         callback -- Custom function for handling tool text outputs.
@@ -4385,7 +4385,7 @@ class WhiteboxTools(object):
         output1 -- Name of the output downslope unsaturated length (DUL) file. 
         output2 -- Name of the output upslope disconnected saturated area (UDSA) file. 
         exponent -- Optional exponent parameter; default is 1.0. 
-        threshold -- Optional convergence threshold parameter, in grid cells; default is inifinity. 
+        threshold -- Optional convergence threshold parameter, in grid cells; default is infinity. 
         callback -- Custom function for handling tool text outputs.
         """
         args = []
@@ -4529,7 +4529,7 @@ class WhiteboxTools(object):
         output -- Output raster file. 
         out_type -- Output type; one of 'cells', 'specific contributing area' (default), and 'catchment area'. 
         exponent -- Optional exponent parameter; default is 1.1. 
-        threshold -- Optional convergence threshold parameter, in grid cells; default is inifinity. 
+        threshold -- Optional convergence threshold parameter, in grid cells; default is infinity. 
         log -- Optional flag to request the output be log-transformed. 
         clip -- Optional flag to request clipping the display max by 1%. 
         callback -- Custom function for handling tool text outputs.
@@ -4568,7 +4568,7 @@ class WhiteboxTools(object):
         out_type -- Output type; one of 'cells', 'specific contributing area' (default), and 'catchment area'. 
         exponent -- Optional upper-bound exponent parameter; default is 10.0. 
         max_slope -- Optional upper-bound slope parameter, in degrees (0-90); default is 45.0. 
-        threshold -- Optional convergence threshold parameter, in grid cells; default is inifinity. 
+        threshold -- Optional convergence threshold parameter, in grid cells; default is infinity. 
         log -- Log-transform the output values?. 
         clip -- Optional flag to request clipping the display max by 1%. 
         callback -- Custom function for handling tool text outputs.
@@ -4593,7 +4593,7 @@ class WhiteboxTools(object):
         output -- Name of the output raster file. 
         out_type -- Output type; one of 'cells', 'specific contributing area' (default), and 'catchment area'. 
         exponent -- Optional exponent parameter; default is 1.0. 
-        threshold -- Optional convergence threshold parameter, in grid cells; default is inifinity. 
+        threshold -- Optional convergence threshold parameter, in grid cells; default is infinity. 
         log -- Log-transform the output values?. 
         clip -- Optional flag to request clipping the display max by 1%. 
         callback -- Custom function for handling tool text outputs.
@@ -6483,7 +6483,7 @@ class WhiteboxTools(object):
         return self.run_tool('lidar_block_minimum', args, callback) # returns 1 if error
 
     def lidar_classify_subset(self, base, subset, output, subset_class, nonsubset_class=None, callback=None):
-        """Classifies the values in one LiDAR point cloud that correpond with points in a subset cloud.
+        """Classifies the values in one LiDAR point cloud that correspond with points in a subset cloud.
 
         Keyword arguments:
 
@@ -6604,7 +6604,7 @@ class WhiteboxTools(object):
         i -- Input LiDAR file. 
         output -- Output LiDAR file. 
         radius -- Search Radius. 
-        min_neighbours -- The minimum number of neighbouring points within search areas. If fewer points than this threshold are idenfied during the fixed-radius search, a subsequent kNN search is performed to identify the k number of neighbours. 
+        min_neighbours -- The minimum number of neighbouring points within search areas. If fewer points than this threshold are identified during the fixed-radius search, a subsequent kNN search is performed to identify the k number of neighbours. 
         slope_threshold -- Maximum inter-point slope to be considered an off-terrain point. 
         height_threshold -- Inter-point height difference to be considered an off-terrain point. 
         classify -- Classify points as ground (2) or off-ground (1). 
@@ -7541,7 +7541,7 @@ class WhiteboxTools(object):
         return self.run_tool('ceil', args, callback) # returns 1 if error
 
     def conditional_evaluation(self, i, output, statement="", true=None, false=None, callback=None):
-        """This tool performs a conditional evaluaton (if-then-else) operation on a raster.
+        """This tool performs a conditional evaluation (if-then-else) operation on a raster.
 
         Keyword arguments:
 
@@ -7798,7 +7798,7 @@ class WhiteboxTools(object):
         input1 -- Input raster file (independent variable, X). 
         input2 -- Input raster file (dependent variable, Y). 
         output -- Output HTML file for regression summary report. 
-        out_residuals -- Output raster regression resdidual file. 
+        out_residuals -- Output raster regression residual file. 
         standardize -- Optional flag indicating whether to standardize the residuals map. 
         scattergram -- Optional flag indicating whether to output a scattergram. 
         num_samples -- Number of samples used to create scattergram. 
@@ -8245,7 +8245,7 @@ class WhiteboxTools(object):
         return self.run_tool('random_sample', args, callback) # returns 1 if error
 
     def raster_calculator(self, output, statement="", callback=None):
-        """This tool performs a conditional evaluaton (if-then-else) operation on a raster.
+        """This tool performs a conditional evaluation (if-then-else) operation on a raster.
 
         Keyword arguments:
 
@@ -9022,7 +9022,7 @@ class WhiteboxTools(object):
         d8_pntr -- Input raster D8 pointer file. 
         streams -- Input raster streams file. 
         output -- Output raster file. 
-        min_length -- Minimum tributary length (in map units) used for network prunning. 
+        min_length -- Minimum tributary length (in map units) used for network pruning. 
         esri_pntr -- D8 pointer uses the ESRI style scheme. 
         callback -- Custom function for handling tool text outputs.
         """


### PR DESCRIPTION
This PR fixes typos that were caught with `devtools::spell_check()` on the `whitebox` R package (https://github.com/giswqs/whiteboxR/) documentation and output in the README with v2.0.0