### PR TITLE
Linting Clippy CI Check

### DIFF
--- a/.github/workflows/clippy_check.yml
+++ b/.github/workflows/clippy_check.yml
@@ -1,0 +1,20 @@
+on: push
+name: Clippy check
+jobs:
+  clippy_check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - id: component
+        uses: actions-rs/components-nightly@v1
+        with:
+          component: clippy
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: ${{ steps.component.outputs.toolchain }}
+          override: true
+      - run: rustup component add clippy
+      - uses: actions-rs/clippy-check@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          args: --all-features

--- a/.github/workflows/clippy_check.yml
+++ b/.github/workflows/clippy_check.yml
@@ -1,4 +1,10 @@
-on: push
+# purpose of this workflow is for running clippy linting checks on pushes and pull requests.
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+
 name: Clippy check
 jobs:
   clippy_check:


### PR DESCRIPTION
I saw a comment in the g-group about adding clippy linting Checks.
figured I would add it.

here is the full summary
https://github.com/seahawks8/whitebox-tools/actions/runs/1429520635

There are currently six linting errors and a few warnings.
After this merge, I will fix the six clippy errors, we can tackle the linting warnings later.
![image](https://user-images.githubusercontent.com/20735170/140617504-213364ea-b6de-4752-ba25-3026c17f39cc.png)
