### PR TITLE
RasterStreamsToVector: add option to keep all vertices

### DIFF
--- a/whitebox-tools-app/src/tools/stream_network_analysis/raster_streams_to_vector.rs
+++ b/whitebox-tools-app/src/tools/stream_network_analysis/raster_streams_to_vector.rs
@@ -82,6 +82,15 @@ impl RasterStreamsToVector {
             optional: true,
         });
 
+        parameters.push(ToolParameter {
+            name: "Do all stream pixels should be represented by a vertex?".to_owned(),
+            flags: vec!["--keep_all_vertices".to_owned()],
+            description: "Avoid any simplification of the output vector.".to_owned(),
+            parameter_type: ParameterType::Boolean,
+            default_value: Some("false".to_owned()),
+            optional: true,
+        });
+
         let sep: String = path::MAIN_SEPARATOR.to_string();
         let e = format!("{}", env::current_exe().unwrap().display());
         let mut parent = env::current_exe().unwrap();
@@ -153,6 +162,7 @@ impl WhiteboxTool for RasterStreamsToVector {
         let mut streams_file = String::new();
         let mut output_file = String::new();
         let mut esri_style = false;
+        let mut keep_all_vertices = false;
 
         if args.len() == 0 {
             return Err(Error::new(
@@ -191,6 +201,10 @@ impl WhiteboxTool for RasterStreamsToVector {
             } else if flag_val == "-esri_pntr" || flag_val == "-esri_style" {
                 if vec.len() == 1 || !vec[1].to_string().to_lowercase().contains("false") {
                     esri_style = true;
+                };
+            } else if flag_val == "-keep_all_vertices" {
+                if vec.len() == 1 || !vec[1].to_string().to_lowercase().contains("false") {
+                    keep_all_vertices = true;
                 }
             }
         }
@@ -365,7 +379,7 @@ impl WhiteboxTool for RasterStreamsToVector {
                 while flag {
                     if pntr.get_value(row, col) != pntr_nodata {
                         dir = pntr.get_value(row, col) as usize;
-                        already_added_point = if dir != prev_dir {
+                        already_added_point = if keep_all_vertices || dir != prev_dir {
                             x = pntr.get_x_from_column(col);
                             y = pntr.get_y_from_row(row);
                             points.push(Point2D::new(x, y));


### PR DESCRIPTION
Tis PR adds the option to keep all vertices when using `RasterStreamsToVector` rather then simplifying when two consecutive directions are the same. Having all vertices can be useful if one wants to implement its own simplification algorithm like one taking into account not only the X and Y change, but also the elevation (Z) change afterward.

![all_vertices](https://user-images.githubusercontent.com/32580398/176244354-fe79a324-5b65-4a6d-8e08-52792508e584.png)

The default behavior is unchanged, the switch `--keep_all_vertices` must be use to see the change.