### PR TITLE
add --weights option to D8FlowAccumulation tool

### DIFF
--- a/whitebox_tools.py
+++ b/whitebox_tools.py
@@ -4579,13 +4579,14 @@ Okay, that's it for now.
         if width is not None: args.append("--width='{}'".format(width))
         return self.run_tool('burn_streams_at_roads', args, callback) # returns 1 if error
 
-    def d8_flow_accumulation(self, i, output, out_type="cells", log=False, clip=False, pntr=False, esri_pntr=False, callback=None):
+    def d8_flow_accumulation(self, i, output, weights=None, out_type="cells", log=False, clip=False, pntr=False, esri_pntr=False, callback=None):
         """Calculates a D8 flow accumulation raster from an input DEM or flow pointer.
 
         Keyword arguments:
 
         i -- Input raster DEM or D8 pointer file. 
         output -- Output raster file. 
+        weights -- Optional input weights raster file.
         out_type -- Output type; one of 'cells' (default), 'catchment area', and 'specific contributing area'. 
         log -- Optional flag to request the output be log-transformed. 
         clip -- Optional flag to request clipping the display max by 1%. 
@@ -4596,6 +4597,7 @@ Okay, that's it for now.
         args = []
         args.append("--input='{}'".format(i))
         args.append("--output='{}'".format(output))
+        if weights is not None: args.append("--weights='{}'".format(weights))
         args.append("--out_type={}".format(out_type))
         if log: args.append("--log")
         if clip: args.append("--clip")


### PR DESCRIPTION
This patch adds a `--weights` option to the `D8FlowAccumulation` tool. A raster containing weight values is provided as the argument:

```sh
whitebox_tools --run=D8FlowAccumulation --input=d8_pnt.tif --output=d8_acc.tif --weights=weights.tif --pntr
```

The weights raster is used to reduce flow accumulation in areas where the weight is less than one. For example, I am using this patch to produce less accumulation in flat areas. I generate a slope raster, and then re-scale it using a ramp function, giving a unit weighting above 15% gradient, down to an 0.2 weighting below 5% gradient:

```sh
whitebox_tools --run=Slope --input=dem.tif --output=gradient.tif --units=percent
whitebox_tools --run=RescaleValueRange --input=gradient.tif --output=weights.tif --clip_min=5 --clip_max=15 --out_min_val=0.2 --out_max_val=1.0
```

I extract streams for topographic maps using this method. The weighting reduces streams in flat areas and looks more natural on the map.
