### PR TITLE
LidarPointStats: more robust determination of row/col position of points

### DIFF
--- a/whitebox-tools-app/src/tools/lidar_analysis/lidar_point_stats.rs
+++ b/whitebox-tools-app/src/tools/lidar_analysis/lidar_point_stats.rs
@@ -391,7 +391,6 @@ impl WhiteboxTool for LidarPointStats {
                     let south: f64 = north - rows as f64 * grid_res;
                     let east = west + columns as f64 * grid_res;
                     let nodata = -32768.0f64;
-                    let half_grid_res = grid_res / 2.0;
                     let ns_range = north - south;
                     let ew_range = east - west;
 
@@ -438,10 +437,12 @@ impl WhiteboxTool for LidarPointStats {
                         for i in 0..n_points {
                             pd = input[i];
                             p = input.get_transformed_coords(i);
-                            col = (((columns - 1) as f64 * (p.x - west - half_grid_res) / ew_range)
-                                .round()) as isize;
-                            row = (((rows - 1) as f64 * (north - half_grid_res - p.y) / ns_range)
-                                .round()) as isize;
+                            col = ((columns as f64 * (p.x - west) / ew_range).floor()) as isize;
+                            row = ((rows as f64 * (north - p.y) / ns_range).floor()) as isize;
+
+                            // Force points exactly on the edge of the raster to be within the last column or row
+                            if col == (columns as isize) { col = col - 1 };
+                            if row == (rows as isize) { row = row - 1 };
 
                             out_num_pnts.increment(row, col, 1f64);
 
@@ -579,10 +580,12 @@ impl WhiteboxTool for LidarPointStats {
                         for i in 0..n_points {
                             pd = input[i];
                             p = input.get_transformed_coords(i);
-                            col = (((columns - 1) as f64 * (p.x - west - half_grid_res) / ew_range)
-                                .round()) as isize;
-                            row = (((rows - 1) as f64 * (north - half_grid_res - p.y) / ns_range)
-                                .round()) as isize;
+                            col = ((columns as f64 * (p.x - west) / ew_range).floor()) as isize;
+                            row = ((rows as f64 * (north - p.y) / ns_range).floor()) as isize;
+
+                            // Force points exactly on the edge of the raster to be within the last column or row
+                            if col == (columns as isize) { col = col - 1 };
+                            if row == (rows as isize) { row = row - 1 };
 
                             new_min_max_z = false;
                             if p.z < min_z.get_value(row, col) {
@@ -699,10 +702,12 @@ impl WhiteboxTool for LidarPointStats {
                         for i in 0..n_points {
                             pd = input[i];
                             p = input.get_transformed_coords(i);
-                            col = (((columns - 1) as f64 * (p.x - west - half_grid_res) / ew_range)
-                                .round()) as isize;
-                            row = (((rows - 1) as f64 * (north - half_grid_res - p.y) / ns_range)
-                                .round()) as isize;
+                            col = ((columns as f64 * (p.x - west) / ew_range).floor()) as isize;
+                            row = ((rows as f64 * (north - p.y) / ns_range).floor()) as isize;
+
+                            // Force points exactly on the edge of the raster to be within the last column or row
+                            if col == (columns as isize) { col = col - 1 };
+                            if row == (rows as isize) { row = row - 1 };
 
                             class = pd.classification();
                             class_histo[class as usize].increment(row, col, 1u16);


### PR DESCRIPTION
Fix https://github.com/jblindsay/whitebox-tools/issues/273

The current way of determining the row/col position of each point wasn't reliable resulting in some points contributing to an adjacent pixel. The proposed method is more robust, but only as long as the extent in the LAS header really contains all points.

The new method also changes the way points exactly on the edge of a pixel are treated:
![image](https://user-images.githubusercontent.com/32580398/188929130-a02bd088-5551-42d4-a03a-5b6cb9cb6932.png)
No way is better than the other, it's just a by-product of the method I used (it could be tweak to give the same result as before). As a side note, LAStools includes points on the left and bottom edges while excluding points on the right and top edges.

Last note, I chose to force points sitting on the easternmostedge of the extent to fall in last column of the raster and in the same way, I force points sitting on the southernmost edge of the extent to fall in the last row. I don't think that's ideal as it breaks the normal way of determining the row/col position. It would also add a small error in the case of tiled files as some points could potentially be counted twice depending on how the tiling has been done.