### PR TITLE
RasterStreamsToVector issue with output projection #301 fixed

### DIFF
--- a/whitebox-tools-app/src/tools/stream_network_analysis/raster_streams_to_vector.rs
+++ b/whitebox-tools-app/src/tools/stream_network_analysis/raster_streams_to_vector.rs
@@ -252,7 +252,7 @@ impl WhiteboxTool for RasterStreamsToVector {
         let mut output = Shapefile::new(&output_file, ShapeType::PolyLine)?;
 
         // set the projection information
-        // output.projection = input.get_wkt();
+        output.projection = streams.configs.coordinate_ref_system_wkt.clone();
 
         // add the attributes
         output


### PR DESCRIPTION
Fix of issue #301 
Output projection assigning was commented.
Now tool sets output shapefile projection from streams input raster.