### PR TITLE
HeightAboveGround: specify LiDAR output file

### DIFF
--- a/whitebox-tools-app/src/tools/lidar_analysis/height_above_ground.rs
+++ b/whitebox-tools-app/src/tools/lidar_analysis/height_above_ground.rs
@@ -62,8 +62,8 @@ impl HeightAboveGround {
         parameters.push(ToolParameter {
             name: "Output File".to_owned(),
             flags: vec!["-o".to_owned(), "--output".to_owned()],
-            description: "Output raster file (including extension).".to_owned(),
-            parameter_type: ParameterType::NewFile(ParameterFileType::Raster),
+            description: "Output LiDAR file (including extension).".to_owned(),
+            parameter_type: ParameterType::NewFile(ParameterFileType::Lidar),
             default_value: None,
             optional: true,
         });
@@ -82,7 +82,7 @@ impl HeightAboveGround {
             short_exe += ".exe";
         }
         let usage = format!(
-            ">>.*{0} -r={1} -v --wd=\"*path*to*data*\" -i=file.las -o=outfile.tif",
+            ">>.*{0} -r={1} -v --wd=\"*path*to*data*\" -i=file.las -o=outfile.las",
             short_exe, name
         )
         .replace("*", &sep);

--- a/whitebox-tools-app/src/tools/lidar_analysis/height_above_ground.rs
+++ b/whitebox-tools-app/src/tools/lidar_analysis/height_above_ground.rs
@@ -423,8 +423,6 @@ impl WhiteboxTool for HeightAboveGround {
             }
         }
 
-        let elapsed_time = get_formatted_elapsed_time(start);
-
         if verbose {
             println!("Writing output LAS file...");
         }
@@ -436,6 +434,8 @@ impl WhiteboxTool for HeightAboveGround {
             }
             Err(e) => println!("error while writing: {:?}", e),
         };
+
+        let elapsed_time = get_formatted_elapsed_time(start);
 
         if verbose {
             println!(


### PR DESCRIPTION
Addresses https://github.com/jblindsay/whitebox-tools/issues/212

The output parameter description was suggesting that the output file would be a raster while a LiDAR (LAS) file was in fact written.

I also moved the place where the clock was stopped in order to really consider the total elapsed time including I/O as intended in this tool.

