### PR TITLE
Mosaic: adds band and datatype checks

### DIFF
--- a/whitebox-raster/src/geotiff/mod.rs
+++ b/whitebox-raster/src/geotiff/mod.rs
@@ -485,10 +485,17 @@ pub fn read_geotiff<'a>(
         }
     };
 
-    // let num_samples = match ifd_map.get(&277) {
-    //     Some(ifd) => ifd.interpret_as_u16()[0],
-    //     _ => 0,
-    // };
+    match ifd_map.get(&277) {
+        Some(ifd) => {
+            configs.bands = ifd.interpret_as_u16()[0] as u8; // warning: a GeoTIFF can contain more than 256 bands
+        }
+        _ => {
+            return Err(Error::new(
+                ErrorKind::InvalidData,
+                "The raster SamplesPerPixel value was not read correctly",
+            ))
+        }
+    };
 
     match ifd_map.get(&280) {
         Some(ifd) => {

--- a/whitebox-tools-app/src/tools/image_analysis/mosaic.rs
+++ b/whitebox-tools-app/src/tools/image_analysis/mosaic.rs
@@ -20,7 +20,7 @@ use std::sync::mpsc;
 use std::sync::Arc;
 use std::thread;
 
-/// This tool will create an image mosaic from one or more input image files using
+/// This tool will create an image mosaic from two or more single band input image files using
 /// one of three resampling methods including, nearest neighbour, bilinear interpolation,
 /// and cubic convolution. The order of the input source image files is important. Grid
 /// cells in the output image will be assigned the corresponding value determined from the
@@ -320,6 +320,16 @@ impl WhiteboxTool for Mosaic {
                 if res.is_ok() {
                     inputs.push(res.unwrap()); //Raster::new(&input_file, "r")?).expect(&format!("Error reading file: {}", value)));
                     nodata_vals.push(inputs[i].configs.nodata);
+                    
+                    if inputs[i].configs.data_type != inputs[0].configs.data_type {
+                        return Err(Error::new(ErrorKind::InvalidInput,
+                            "There is something incorrect about the input files. All inputs must be of the same data type."));
+                    }
+
+                    if inputs[i].configs.bands > 1 {
+                        return Err(Error::new(ErrorKind::InvalidInput,
+                            "There is something incorrect about the input files. All inputs must be single band."));
+                    }
 
                     if i == 0 {
                         if inputs[i].configs.north < inputs[i].configs.south {


### PR DESCRIPTION
Partially fix https://github.com/jblindsay/whitebox-tools/issues/309

Explicitly tell the user that the tool can only work with single band and single data type rasters. I had to modify the GeoTiff reader in order to expose the number of bands inside a GeoTiff as before is was always set to one.

A better solution would be to edit the tool in order for it to accept multiband raster but that is more work.