### PR TITLE
DownFlowpathLength: additional check if direction fall into nodata

### DIFF
--- a/whitebox-tools-app/src/tools/hydro_analysis/downslope_flowpath_length.rs
+++ b/whitebox-tools-app/src/tools/hydro_analysis/downslope_flowpath_length.rs
@@ -360,14 +360,15 @@ impl WhiteboxTool for DownslopeFlowpathLength {
                         // find its downslope neighbour
                         dir = pntr.get_value(y, x);
                         if dir > 0f64 && dir != nodata {
-                            if dir > 128f64 || pntr_matches[dir as usize] == 999 {
-                                return Err(Error::new(ErrorKind::InvalidInput,
-                                    "An unexpected value has been identified in the pointer image. This tool requires a pointer grid that has been created using either the D8 or Rho8 tools."));
-                            }
-                            // move x and y accordingly
+                             // move x and y accordingly
                             c = pntr_matches[dir as usize];
                             x += dx[c];
                             y += dy[c];
+
+                            if dir > 128f64 || c == 999 || pntr.get_value(y, x) == nodata {
+                                return Err(Error::new(ErrorKind::InvalidInput,
+                                    "An unexpected value has been identified in the pointer image. This tool requires a pointer grid that has been created using either the D8 or Rho8 tools."));
+                            }
 
                             dist += grid_lengths[c] * weights.get_value(y, x) as f64;
 


### PR DESCRIPTION
Fix #300

If the value in one pixel of the D8Pointer points into NoData, the tool won't crash but will output wrong result. This PR adds a safeguard to prevent this and inform the user that there is an issue with the input file. Alternativevly, the code could be modified in ordre to ignore such a pixel and consider it as `0` but I think that it is better to not silence this kind of issue in a D8 pointer.

Also, I didn't edit the message as it is still valid, but it may be more useful to the user if the message included the row and column number of the pixel causing the error.