### PR TITLE
Reclass: 'max' and 'nodata' as valid values

### DIFF
--- a/whitebox-tools-app/src/tools/gis_analysis/reclass.rs
+++ b/whitebox-tools-app/src/tools/gis_analysis/reclass.rs
@@ -32,6 +32,7 @@ use std::thread;
 ///
 /// Here, 0.0 is assigned to input grid cell values of 1.0 and 1.0 is output for all input cells with a value of 2.0. Users
 /// may add the text strings *min* and *max* in the class definitions to stand in for the raster's minimum and maximum values.
+/// Using *max* in a class triplet will change this class from *To Just Less Than* to *To Less Or Equal Than*.
 /// For example:
 ///
 /// > --reclass_vals='0.0;min;1.0;1.0;1.0;max'
@@ -255,7 +256,9 @@ impl WhiteboxTool for Reclass {
                 if s.to_lowercase().contains("min") {
                     min_val
                 } else if s.to_lowercase().contains("max") {
-                    max_val
+                    max_val + 0.1f64
+                } else if s.to_lowercase().contains("nodata") {
+                    nodata
                 } else {
                     s.trim().parse().unwrap()
                 }


### PR DESCRIPTION
Additional fix for #67 and #90.

Usage of `max` was already allowed, but with the current implementation, le maximal value itself would always be excluded from the reclassification. I think we can safely assume that if a one uses `max`, the intent is to include it in the reclassification. So I chose to add 0.1 to the maximal value to make sure that the original value would be included in the class. I choose 0.1 instead of 1 thinking that if the input is a Uint8 with a NoData value of 255 and a max value of 254, we don't want to rewrite the NoData cells in the process.

I also implemented the `nodata` string as a valid value. It was simply forgotten in the initial fix.

