### PR TITLE
allow whitebox executable to be symlinked

### DIFF
--- a/whitebox-tools-app/src/tools/mod.rs
+++ b/whitebox-tools-app/src/tools/mod.rs
@@ -1199,7 +1199,7 @@ impl ToolManager {
 
     fn get_plugin_list(&self) -> Result<HashMap<String, serde_json::Value>, Error> {
         // let exe_path = std::env::current_dir()?.to_str().unwrap_or("No exe path found.").to_string();
-        let mut dir = env::current_exe()?;
+        let mut dir = fs::canonicalize(env::current_exe()?)?;
         dir.pop();
         dir.push("plugins");
         let plugin_directory = dir.to_str().unwrap_or("No exe path found.").to_string();


### PR DESCRIPTION
This minor patch causes a fully-resolved path for the whitebox executable to be used when locating the plugins folder. This allows the executable to be symlinked from another location.

I maintain the Whitebox Tools package for MacPorts (a macOS packaging system). As is usual for unix-style packaging systems, MacPorts installs all binaries in a standard location, `/opt/local/bin`. This causes a problem for the whitebox plugins, whose paths are hard-coded to be in a `plugins` subdirectory co-located with the main executable. It's not feasible to have such a folder located in a shared directory. Instead I symlink the `whitebox_tools` binary from another location where it and the `plugins` subdirectory reside. The submitted patch resolves such a symlink and allows the plugins directory to be successfully located.


