### PR TITLE
Ensure consistent pit cells ordering before breaching

### DIFF
--- a/whitebox-tools-app/src/tools/hydro_analysis/breach_depressions_least_cost.rs
+++ b/whitebox-tools-app/src/tools/hydro_analysis/breach_depressions_least_cost.rs
@@ -458,7 +458,12 @@ impl WhiteboxTool for BreachDepressionsLeastCost {
         ////////////////////////////////////////////////////////////////////////////////////////////
 
         /* Vec is a stack and so if we want to pop the values from lowest to highest, we need to sort
-        them from highest to lowest. */
+        them from highest to lowest. The stack being built with parallelism, the order in which the
+        values are added can't be garanted from run to run meaning that a simple sort by height might
+        lead to different breaching solutions caused by a different processing order if two pits have
+        the same height. To avoid this, pit cells are sorted first by X, then by Y and finally by height.*/
+        undefined_flow_cells.sort_by(|a, b| b.0.partial_cmp(&a.0).unwrap_or(Equal));
+        undefined_flow_cells.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap_or(Equal));
         undefined_flow_cells.sort_by(|a, b| b.2.partial_cmp(&a.2).unwrap_or(Equal));
         let num_deps = undefined_flow_cells.len();
         if num_deps == 0 && verbose {
@@ -475,6 +480,8 @@ impl WhiteboxTool for BreachDepressionsLeastCost {
         let filter_size = ((max_dist * 2 + 1) * (max_dist * 2 + 1)) as usize;
         let mut minheap = BinaryHeap::with_capacity(filter_size);
         while let Some(cell) = undefined_flow_cells.pop() {
+            // Height is retrieved from the output raster instead of the popped cell because
+            // the current height could have been modified by a previous breaching iteration
             row = cell.0;
             col = cell.1;
             z = output.get_value(row, col);


### PR DESCRIPTION
Fix #418

Make sure that each run of the tool gives the same output. This is needed because the stack is built using parallel processing meaning that the values aren't always in the same order. This isn't an issue as long as their is no height ties... which happen quite often. Sorting first by X and Y ensure consistent ordering as this XY tuple is unique for each cell.

My PR use three consecutive `sort_by()` but I'm sure there is an more elegant or concise way to do it. An alternative might be to build the stack while keeping track of each row.