### PR TITLE
Add optional `--seed` parameter to Rho8Pointer

### DIFF
--- a/whitebox_tools.py
+++ b/whitebox_tools.py
@@ -5484,7 +5484,7 @@ Okay, that's it for now.
         if esri_pntr: args.append("--esri_pntr")
         return self.run_tool('rho8_flow_accumulation', args, callback) # returns 1 if error
 
-    def rho8_pointer(self, dem, output, esri_pntr=False, callback=None):
+    def rho8_pointer(self, dem, output, esri_pntr=False, seed=None, callback=None):
         """Calculates a stochastic Rho8 flow pointer raster from an input DEM.
 
         Keyword arguments:
@@ -5492,12 +5492,14 @@ Okay, that's it for now.
         dem -- Input raster DEM file. 
         output -- Output raster file. 
         esri_pntr -- D8 pointer uses the ESRI style scheme. 
+        seed -- Seed to initialize stochastic function. 
         callback -- Custom function for handling tool text outputs.
         """
         args = []
         args.append("--dem='{}'".format(dem))
         args.append("--output='{}'".format(output))
         if esri_pntr: args.append("--esri_pntr")
+        if seed is not None: args.append("--seed='{}'".format(seed))
         return self.run_tool('rho8_pointer', args, callback) # returns 1 if error
 
     def river_centerlines(self, i, output, min_length=3, radius=4, callback=None):


### PR DESCRIPTION
Due to the stochastic nature of the Rho8 algorithm in its current implementation, it is not possible to get the same output two times from Rho8Pointer which could be an issue in research and development as it doesn't allow reproducible results. This PR adds an optional `-seed` parameter for cases where a result must be replicated.

It must be noted that I changed the original random number generator `rand::thread_rng()` by `StdRng::from_entropy()` in order to make it compatible with the seeded generator `StdRng::seed_from_u64()`. I don't think it will have any impact on the randomness of the original method, but I don't know enough about theses functions to be sure.

As, there is currently no check to make sure that a positive integer was provided to `--seed`, the current code will panic if a negative integer is provided.