### PR TITLE
Fix no arg in network analysis causing break, whitebox_tools.py

### DIFF
--- a/whitebox_tools.py
+++ b/whitebox_tools.py
@@ -10652,7 +10652,7 @@ Okay, that's it for now.
         if zero_background: args.append("--zero_background")
         return self.run_tool('tributary_identifier', args, callback) # returns 1 if error
 
-    def vector_stream_network_analysis(self, streams, output, snap=0.1, callback=None):
+    def vector_stream_network_analysis(self, streams, dem, output, snap=0.1, callback=None):
         """This tool performs common stream network analysis operations on an input vector stream file.
 
         Keyword arguments:


### PR DESCRIPTION
In vector_stream_network_analysis, the tool expects dem but no dem arg was provided for the python wrapper definition. Simpy added a dem arg