### PR TITLE
Fix default value for max_norm_diff

### DIFF
--- a/whitebox-tools-app/src/tools/terrain_analysis/feature_preserving_smoothing.rs
+++ b/whitebox-tools-app/src/tools/terrain_analysis/feature_preserving_smoothing.rs
@@ -222,7 +222,7 @@ impl WhiteboxTool for FeaturePreservingSmoothing {
         let mut input_file = String::new();
         let mut output_file = String::new();
         let mut filter_size = 11usize;
-        let mut max_norm_diff = 8f32;
+        let mut max_norm_diff = 15f32;
         let mut num_iter = 3;
         let mut z_factor = -1f32;
         let mut max_z_diff = f32::INFINITY;


### PR DESCRIPTION
The parameter description states that the default is 15, but if not specified then the actual default used was 8. I've updated this to match the parameter description instead (i.e. 15)